### PR TITLE
Add hotfolder watcher

### DIFF
--- a/MillerLieblingskind/main.py
+++ b/MillerLieblingskind/main.py
@@ -47,19 +47,14 @@ def speak_text(text: str):
     playsound(filename)
     os.remove(filename)
 
-def main():
-    parser = argparse.ArgumentParser(description="Process a scanned PDF document.")
-    parser.add_argument("pdf", help="Path to the PDF file")
-    parser.add_argument("--slack-token", help="Slack API token", dest="slack_token")
-    parser.add_argument("--slack-channel", help="Slack channel ID", dest="slack_channel")
-    parser.add_argument("--tts", action="store_true", help="Read tasks aloud")
-    args = parser.parse_args()
 
-    text = pdf_to_text(args.pdf)
+def process_pdf(pdf_path: str, slack_token: str | None = None, slack_channel: str | None = None, tts: bool = False) -> None:
+    """Process a single PDF document using the standard pipeline."""
+    text = pdf_to_text(pdf_path)
     doc_type = classify_document(text)
     tasks = extract_tasks(text)
 
-    archived_path = save_document(args.pdf, doc_type)
+    archived_path = save_document(pdf_path, doc_type)
 
     tasks_json = json.dumps(tasks, indent=2, ensure_ascii=False)
     print(f"Dokumenttyp: {doc_type}")
@@ -67,12 +62,22 @@ def main():
     print("Gefundene Aufgaben:")
     print(tasks_json)
 
-    if args.slack_token and args.slack_channel:
+    if slack_token and slack_channel:
         message = f"Dokumenttyp: {doc_type}\nAufgaben: {tasks_json}"
-        send_slack_message(args.slack_token, args.slack_channel, message)
+        send_slack_message(slack_token, slack_channel, message)
 
-    if args.tts:
+    if tts:
         speak_text(tasks_json)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Process a scanned PDF document.")
+    parser.add_argument("pdf", help="Path to the PDF file")
+    parser.add_argument("--slack-token", help="Slack API token", dest="slack_token")
+    parser.add_argument("--slack-channel", help="Slack channel ID", dest="slack_channel")
+    parser.add_argument("--tts", action="store_true", help="Read tasks aloud")
+    args = parser.parse_args()
+    process_pdf(args.pdf, args.slack_token, args.slack_channel, args.tts)
 
 if __name__ == "__main__":
     main()

--- a/README.md
+++ b/README.md
@@ -7,7 +7,16 @@ Dieses Unterprojekt analysiert eingescannte PDF-Dokumente automatisch. Es demons
 
 ### Struktur
 - `main.py` – Einstiegspunkt
+- `hotfolder.py` – Beobachtet einen Ordner und verarbeitet automatisch neue PDFs
 - `utils/ocr_engine.py` – OCR von PDF-Dateien
 - `utils/document_classifier.py` – Einfache Dokumentklassifizierung
 - `utils/task_extractor.py` – Extraktion von Aufgaben und Fristen
 - `requirements.txt` – Benötigte Python-Pakete
+
+### Hotfolder verwenden
+
+Mit `hotfolder.py` lässt sich ein Ordner überwachen, in den neue PDF-Dateien gelegt werden. Jede gefundene Datei wird einmalig verarbeitet und anschließend archiviert. Beispiel:
+
+```bash
+python hotfolder.py /pfad/zum/hotfolder --interval 10
+```

--- a/hotfolder.py
+++ b/hotfolder.py
@@ -1,0 +1,38 @@
+import argparse
+import os
+import time
+
+from MillerLieblingskind.main import process_pdf
+
+
+def monitor_folder(folder: str, slack_token: str | None, slack_channel: str | None, tts: bool, interval: int) -> None:
+    os.makedirs(folder, exist_ok=True)
+    print(f"Scanning '{folder}' every {interval}s for PDF files...")
+    while True:
+        for name in os.listdir(folder):
+            if not name.lower().endswith(".pdf"):
+                continue
+            path = os.path.join(folder, name)
+            if not os.path.isfile(path):
+                continue
+            try:
+                process_pdf(path, slack_token, slack_channel, tts)
+            except Exception as exc:
+                print(f"Failed to process {path}: {exc}")
+        time.sleep(interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Monitor a hotfolder for new PDF files")
+    parser.add_argument("folder", nargs="?", default="hotfolder", help="Folder to monitor")
+    parser.add_argument("--interval", type=int, default=5, help="Polling interval in seconds")
+    parser.add_argument("--slack-token", dest="slack_token", help="Slack API token")
+    parser.add_argument("--slack-channel", dest="slack_channel", help="Slack channel ID")
+    parser.add_argument("--tts", action="store_true", help="Read tasks aloud")
+    args = parser.parse_args()
+    monitor_folder(args.folder, args.slack_token, args.slack_channel, args.tts, args.interval)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- allow PDF processing functions to be reused via new `process_pdf` helper
- implement `hotfolder.py` to monitor a folder and handle PDFs automatically
- document hotfolder usage in the README

## Testing
- `python3 -m py_compile hotfolder.py MillerLieblingskind/main.py MillerLieblingskind/utils/*.py`

------
https://chatgpt.com/codex/tasks/task_b_687bcd026dec8328806a52a06ba0c06a