### PR TITLE
Add installation hint on first run

### DIFF
--- a/MillerLieblingskind/main.py
+++ b/MillerLieblingskind/main.py
@@ -3,9 +3,10 @@ import json
 import os
 from datetime import datetime
 
-from utils.ocr_engine import pdf_to_text
-from utils.document_classifier import classify_document
-from utils.task_extractor import extract_tasks
+from MillerLieblingskind.utils.ocr_engine import pdf_to_text
+from MillerLieblingskind.utils.document_classifier import classify_document
+from MillerLieblingskind.utils.task_extractor import extract_tasks
+from MillerLieblingskind.utils.install_hint import check_first_run
 
 try:
     from slack_sdk import WebClient
@@ -71,6 +72,7 @@ def process_pdf(pdf_path: str, slack_token: str | None = None, slack_channel: st
 
 
 def main():
+    check_first_run()
     parser = argparse.ArgumentParser(description="Process a scanned PDF document.")
     parser.add_argument("pdf", help="Path to the PDF file")
     parser.add_argument("--slack-token", help="Slack API token", dest="slack_token")

--- a/MillerLieblingskind/utils/install_hint.py
+++ b/MillerLieblingskind/utils/install_hint.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+SENTINEL = Path.home() / ".ai_ablage_initialized"
+
+
+def check_first_run() -> None:
+    """Print installation instructions on first run."""
+    if not SENTINEL.exists():
+        print("Erste Ausf\u00fchrung erkannt. Bitte installieren Sie die Abh\u00e4ngigkeiten mit:\n"
+              "    pip install -r MillerLieblingskind/requirements.txt\n")
+        try:
+            SENTINEL.touch()
+        except Exception:
+            pass

--- a/hotfolder.py
+++ b/hotfolder.py
@@ -2,6 +2,8 @@ import argparse
 import os
 import time
 
+from MillerLieblingskind.utils.install_hint import check_first_run
+
 from MillerLieblingskind.main import process_pdf
 
 
@@ -23,6 +25,7 @@ def monitor_folder(folder: str, slack_token: str | None, slack_channel: str | No
 
 
 def main() -> None:
+    check_first_run()
     parser = argparse.ArgumentParser(description="Monitor a hotfolder for new PDF files")
     parser.add_argument("folder", nargs="?", default="hotfolder", help="Folder to monitor")
     parser.add_argument("--interval", type=int, default=5, help="Polling interval in seconds")


### PR DESCRIPTION
## Summary
- print installation instructions the first time the scripts are executed
- ensure absolute imports so hotfolder works when imported

## Testing
- `python -m py_compile hotfolder.py MillerLieblingskind/main.py MillerLieblingskind/utils/*.py`
- `python MillerLieblingskind/main.py --help | head -n 5`
- `python hotfolder.py --help | head -n 5`

------
https://chatgpt.com/codex/tasks/task_b_687bd52f6fb88328b39d3dc58f5a56c7