### PR TITLE
Fix imports for MillerLieblingskind

### DIFF
--- a/MillerLieblingskind/main.py
+++ b/MillerLieblingskind/main.py
@@ -4,9 +4,17 @@ import os
 import logging
 from datetime import datetime
 
-from utils.ocr_engine import pdf_to_text
-from utils.document_classifier import classify_document
-from utils.task_extractor import extract_tasks
+# Support execution both as a script and as a module
+if __package__:
+    # Imported via "MillerLieblingskind.main" - use relative imports
+    from .utils.ocr_engine import pdf_to_text
+    from .utils.document_classifier import classify_document
+    from .utils.task_extractor import extract_tasks
+else:
+    # Executed directly - fall back to absolute imports
+    from utils.ocr_engine import pdf_to_text
+    from utils.document_classifier import classify_document
+    from utils.task_extractor import extract_tasks
 from dotenv import load_dotenv
 
 LOG_DIR = "logs"


### PR DESCRIPTION
## Summary
- allow `MillerLieblingskind.main` to be imported as a package
- still support running the module directly

## Testing
- `python -m py_compile hotfolder.py MillerLieblingskind/main.py`
- `python hotfolder.py --help` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install -r MillerLieblingskind/requirements.txt` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_687beb55b6a883289083f876a1a0866f