### PR TITLE
Improve OCR engine error reporting

### DIFF
--- a/MillerLieblingskind/utils/ocr_engine.py
+++ b/MillerLieblingskind/utils/ocr_engine.py
@@ -5,9 +5,11 @@ from typing import List
 try:
     from pdf2image import convert_from_path
     import pytesseract
+    from pytesseract import TesseractNotFoundError
 except ImportError:
     convert_from_path = None
     pytesseract = None
+    TesseractNotFoundError = RuntimeError
 
 
 def pdf_to_text(pdf_path: str) -> str:
@@ -18,6 +20,11 @@ def pdf_to_text(pdf_path: str) -> str:
     pages: List[str] = []
     images = convert_from_path(pdf_path)
     for image in images:
-        page_text = pytesseract.image_to_string(image, lang="deu")
+        try:
+            page_text = pytesseract.image_to_string(image, lang="deu")
+        except TesseractNotFoundError as exc:
+            raise RuntimeError(
+                "Tesseract executable not found. Install tesseract-ocr and make sure it is in your PATH."
+            ) from exc
         pages.append(page_text)
     return "\n".join(pages)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ Dieses Unterprojekt analysiert eingescannte PDF-Dokumente automatisch. Es demons
 - `utils/task_extractor.py` – Extraktion von Aufgaben und Fristen
 - `requirements.txt` – Benötigte Python-Pakete
 
+### Zusätzliche Abhängigkeiten
+
+Für die OCR muss das Tesseract-Binary installiert sein. Unter Debian/Ubuntu
+lässt es sich mit
+
+```bash
+sudo apt-get install tesseract-ocr
+```
+
+installieren. Auf macOS kann stattdessen `brew install tesseract` verwendet
+werden. Achte darauf, dass das `tesseract`-Kommando im `PATH` liegt, damit
+`pytesseract` es finden kann.
+
 ### Hotfolder verwenden
 
 Mit `hotfolder.py` lässt sich ein Ordner überwachen, in den neue PDF-Dateien gelegt werden. Jede gefundene Datei wird einmalig verarbeitet und anschließend archiviert. Beispiel:


### PR DESCRIPTION
## Summary
- catch `TesseractNotFoundError` in `ocr_engine.pdf_to_text`
- document the need to install the Tesseract binary in the README

## Testing
- `python3 -m py_compile MillerLieblingskind/utils/ocr_engine.py`
- `python3 MillerLieblingskind/main.py --help` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_687bef69d4208328837b2eff90b00dc7