### PR TITLE
Improve tessdata lookup

### DIFF
--- a/MillerLieblingskind/utils/ocr_engine.py
+++ b/MillerLieblingskind/utils/ocr_engine.py
@@ -17,6 +17,8 @@ except ImportError:
 DEFAULT_TESSDATA_PATHS = [
     "/usr/share/tesseract-ocr/5/tessdata",
     "/usr/share/tesseract-ocr/4.00/tessdata",
+    "/usr/share/tesseract-ocr/tessdata",
+    "/usr/share/tessdata",
     "/usr/local/share/tessdata",
     "/opt/homebrew/share/tessdata",
 ]


### PR DESCRIPTION
## Summary
- extend tessdata search paths in the OCR helper

## Testing
- `python -m py_compile hotfolder.py MillerLieblingskind/*.py MillerLieblingskind/utils/*.py`

------
https://chatgpt.com/codex/tasks/task_b_687bf77b4dac8328ac949a97a79c5583