### PR TITLE
Add PDF summary & keep option

### DIFF
--- a/MillerLieblingskind/main.py
+++ b/MillerLieblingskind/main.py
@@ -3,6 +3,13 @@ import json
 import os
 import logging
 from datetime import datetime
+import shutil
+import re
+
+try:
+    from PyPDF2 import PdfReader
+except ImportError:  # pragma: no cover - optional dependency
+    PdfReader = None
 
 # Support execution both as a script and as a module
 if __package__:
@@ -40,15 +47,48 @@ except ImportError:
     gTTS = None
     playsound = None
 
-def save_document(pdf_path: str, doc_type: str) -> str:
-    """Save the PDF to a structured folder hierarchy based on document type."""
+
+def get_pdf_author(pdf_path: str) -> str:
+    """Return the author of ``pdf_path`` if available."""
+    if PdfReader is None:
+        return "Unknown"
+    try:
+        reader = PdfReader(pdf_path)
+        info = reader.metadata
+        author = getattr(info, "author", None)
+    except Exception:  # pragma: no cover - best effort
+        author = None
+    if not author:
+        return "Unknown"
+    return str(author)
+
+
+def summarize_text(text: str, max_sentences: int = 3) -> str:
+    """Return a naive summary consisting of the first ``max_sentences``."""
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    return " ".join(sentences[:max_sentences]).strip()
+
+def _sanitize_filename(name: str) -> str:
+    """Return a filesystem friendly version of ``name``."""
+    name = re.sub(r"[^a-zA-Z0-9_.-]", "_", name)
+    return name
+
+
+def save_document(pdf_path: str, doc_type: str, author: str, keep: bool) -> str:
+    """Save ``pdf_path`` to ``archive/author`` with a unique short filename."""
     date_str = datetime.now().strftime("%Y_%m_%d_%H%M%S")
     base_name = os.path.basename(pdf_path)
+    base_name = _sanitize_filename(base_name)
     new_name = f"{doc_type}_{date_str}_{base_name}"
-    target_dir = os.path.join("archive", doc_type)
+    if len(new_name) > 32:
+        new_name = new_name[:32]
+    target_dir = os.path.join("archive", _sanitize_filename(author))
     os.makedirs(target_dir, exist_ok=True)
     target_path = os.path.join(target_dir, new_name)
-    os.rename(pdf_path, target_path)
+    if keep:
+        shutil.copy2(pdf_path, target_path)
+    else:
+        os.rename(pdf_path, target_path)
     return target_path
 
 def send_slack_message(token: str, channel: str, text: str):
@@ -76,19 +116,28 @@ def process_pdf(
     slack_token: str | None = None,
     slack_channel: str | None = None,
     tts: bool = False,
+    keep: bool = False,
 ) -> dict:
-    """Process a single PDF document using the standard pipeline."""
+    """Process a single PDF document using the standard pipeline.
+
+    When ``keep`` is ``True`` the source PDF is not removed so it can be
+    processed multiple times for debugging or testing.
+    """
     text = pdf_to_text(pdf_path)
     doc_type = classify_document(text)
     tasks = extract_tasks(text)
+    author = get_pdf_author(pdf_path)
 
-    archived_path = save_document(pdf_path, doc_type)
+    archived_path = save_document(pdf_path, doc_type, author, keep)
+    summary_text = summarize_text(text)
 
     tasks_json = json.dumps(tasks, indent=2, ensure_ascii=False)
     print(f"Dokumenttyp: {doc_type}")
     print(f"Gespeichert unter: {archived_path}")
     print("Gefundene Aufgaben:")
     print(tasks_json)
+    print("Kurze Zusammenfassung:")
+    print(summary_text)
 
     if slack_token and slack_channel:
         message = f"Dokumenttyp: {doc_type}\nAufgaben: {tasks_json}"
@@ -102,6 +151,8 @@ def process_pdf(
         "archived": archived_path,
         "document_type": doc_type,
         "tasks": tasks,
+        "author": author,
+        "summary": summary_text,
     }
     logging.info("Processed %s as %s", pdf_path, archived_path)
     logging.info("Summary: %s", summary)
@@ -116,13 +167,18 @@ def main():
     parser.add_argument("--slack-token", dest="slack_token", help="Slack API token")
     parser.add_argument("--slack-channel", dest="slack_channel", help="Slack channel ID")
     parser.add_argument("--tts", action="store_true", help="Read tasks aloud")
+    parser.add_argument(
+        "--keep", action="store_true", help="Keep original PDF for debug/testing"
+    )
     args = parser.parse_args()
 
     load_dotenv()
     args.slack_token = args.slack_token or os.getenv("SLACK_TOKEN")
     args.slack_channel = args.slack_channel or os.getenv("SLACK_CHANNEL")
 
-    summary = process_pdf(args.pdf, args.slack_token, args.slack_channel, args.tts)
+    summary = process_pdf(
+        args.pdf, args.slack_token, args.slack_channel, args.tts, args.keep
+    )
     print("Zusammenfassung:")
     print(json.dumps(summary, indent=2, ensure_ascii=False))
 

--- a/MillerLieblingskind/requirements.txt
+++ b/MillerLieblingskind/requirements.txt
@@ -4,3 +4,4 @@ slack_sdk
 gtts
 playsound
 python-dotenv
+PyPDF2

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ aussagekräftige Fehlermeldung ausgegeben.
 Mit `hotfolder.py` lässt sich ein Ordner überwachen, in den neue PDF-Dateien gelegt werden. Jede gefundene Datei wird einmalig verarbeitet und anschließend archiviert. Beispiel:
 
 ```bash
-python hotfolder.py /pfad/zum/hotfolder --interval 10
+python hotfolder.py /pfad/zum/hotfolder --interval 10 --keep
 ```
+Das Flag `--keep` ist optional und verhindert, dass die
+verarbeiteten PDF-Dateien verschoben werden.
 
 ### Konfiguration
 
@@ -53,3 +55,13 @@ Leg eine Datei `.env` im Projektverzeichnis an und fülle sie nach dem Vorbild v
 ### Logging
 
 Während der Verarbeitung werden Protokolle und Zusammenfassungen unter `logs/` abgelegt.
+
+### Neuerungen
+
+- PDFs werden nun anhand der im Dokument hinterlegten Author-Information in
+  Unterordnern gespeichert.
+- Die Dateinamen in `archive/` sind auf 32 Zeichen begrenzt.
+- Über die Option `--keep` können die Originaldateien beim Verarbeiten
+  behalten werden, sodass sie mehrfach eingelesen werden können.
+- Bei der Verarbeitung wird zusätzlich eine kurze Textzusammenfassung
+  ausgegeben und protokolliert.

--- a/hotfolder.py
+++ b/hotfolder.py
@@ -18,7 +18,14 @@ logging.basicConfig(
 )
 
 
-def monitor_folder(folder: str, slack_token: str | None, slack_channel: str | None, tts: bool, interval: int) -> None:
+def monitor_folder(
+    folder: str,
+    slack_token: str | None,
+    slack_channel: str | None,
+    tts: bool,
+    interval: int,
+    keep: bool,
+) -> None:
     os.makedirs(folder, exist_ok=True)
     logging.info("Scanning '%s' every %ds for PDF files...", folder, interval)
     while True:
@@ -29,7 +36,7 @@ def monitor_folder(folder: str, slack_token: str | None, slack_channel: str | No
             if not os.path.isfile(path):
                 continue
             try:
-                summary = process_pdf(path, slack_token, slack_channel, tts)
+                summary = process_pdf(path, slack_token, slack_channel, tts, keep)
                 logging.info("Processed %s", summary["pdf"])
             except Exception as exc:
                 logging.exception("Failed to process %s: %s", path, exc)
@@ -43,13 +50,23 @@ def main() -> None:
     parser.add_argument("--slack-token", dest="slack_token", help="Slack API token")
     parser.add_argument("--slack-channel", dest="slack_channel", help="Slack channel ID")
     parser.add_argument("--tts", action="store_true", help="Read tasks aloud")
+    parser.add_argument(
+        "--keep", action="store_true", help="Keep original PDFs for debugging"
+    )
     args = parser.parse_args()
 
     load_dotenv()
     args.slack_token = args.slack_token or os.getenv("SLACK_TOKEN")
     args.slack_channel = args.slack_channel or os.getenv("SLACK_CHANNEL")
 
-    monitor_folder(args.folder, args.slack_token, args.slack_channel, args.tts, args.interval)
+    monitor_folder(
+        args.folder,
+        args.slack_token,
+        args.slack_channel,
+        args.tts,
+        args.interval,
+        args.keep,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- parse author info from PDFs and store archived files in author folders
- cap archived filenames at 32 chars
- allow keeping original PDFs for debugging
- provide naive text summary for processed PDFs
- document new behaviour and dependencies

## Testing
- `python -m py_compile MillerLieblingskind/main.py hotfolder.py MillerLieblingskind/utils/*.py`

------
https://chatgpt.com/codex/tasks/task_b_687bfaed8dc483289cb7e208e626b6be